### PR TITLE
Add a mostly copy-pasted route to support adding this as a slash command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ typeset equations by starting your message with `math!`. For example, `math!
 x^2 * sin(x)` would cause the `mathslax` bot to comment with a link to a
 typeset image of `x^2 * sin(x)`.
 
+## Slash command
+
+You can also use this as a slash command, provided the POST URL is `/command` instead of `/typeset`.
+
 ### Note About Debian/Ubuntu node vs nodejs
 
 The npm install step can produce hard to diagnose errors on Debian derived systems

--- a/server.js
+++ b/server.js
@@ -12,6 +12,37 @@ var router = Express.Router();
 router.get('/', function(req, res) {
   res.json(['Hello', 'World', {underDevelopment: true}]);
 });
+router.post('/command', function(req, res) {
+  var cd = new Date();
+  var requestString = req.body.text;
+  console.log(cd + ":" + requestString);
+  var typesetPromise = Typeset.typeset(requestString,'');
+  if (typesetPromise === null) {
+    res.send('no text found to typeset');
+    res.end(); // Empty 200 response -- no text was found to typeset.
+    return;
+  }
+  var promiseSuccess = function(mathObjects) {
+    var locals = {'mathObjects': mathObjects,
+                  'serverAddress': util.format('https://%s:%s/', SERVER, PORT)};
+    var htmlResult = Jade.renderFile('./views/slack-response.jade', locals);
+    res.json({
+      attachments: [
+        {
+          fallback: requestString,
+          image_url: htmlResult,
+        },
+      ],
+    });
+    res.end();
+  };
+  var promiseError = function(error) {
+    console.log('Error in typesetting:');
+    console.log(error);
+    res.end(); // Empty 200 response.
+  };
+  typesetPromise.then(promiseSuccess, promiseError);
+});
 router.post('/typeset', function(req, res) {
   var cd = new Date();
   var requestString = req.body.text;

--- a/server.js
+++ b/server.js
@@ -27,6 +27,8 @@ router.post('/command', function(req, res) {
                   'serverAddress': util.format('https://%s:%s/', SERVER, PORT)};
     var htmlResult = Jade.renderFile('./views/slack-response.jade', locals);
     res.json({
+      response_type: "in_channel",
+      text: requestString,
       attachments: [
         {
           fallback: requestString,


### PR DESCRIPTION
This is ugly, but effective — I've used this to support a `/math` command in Slack.
