### PR TITLE
Issue Fixed: unescaping HTML special characters (incl. miscellaneous fixs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/batik

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+npm-debug.log
 /batik

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ var BodyParser = require('body-parser');
 var Jade = require('jade');
 var Typeset = require('./typeset.js');
 var util = require('util');
+var entities = require("entities");
 
 var SERVER = process.env.SERVER || '127.0.0.1';
 var PORT = process.env.PORT || '8080';
@@ -14,7 +15,7 @@ router.get('/', function(req, res) {
 });
 router.post('/typeset', function(req, res) {
   var cd = new Date();
-  var requestString = req.body.text;
+  var requestString = entities.decode(req.body.text);
   var bpr = 'math\\!';
   console.log(cd + ":" + requestString);
   console.log( " going to send "+bpr );
@@ -40,7 +41,7 @@ router.post('/typeset', function(req, res) {
 });
 router.post('/slashtypeset', function(req, res) {
   var cd = new Date();
-  var requestString = req.body.text;
+  var requestString = entities.decode(req.body.text);
   var typesetPromise = Typeset.typeset(requestString,'');
   if (typesetPromise === null) {
     res.send('no text found to typeset');

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ router.post('/typeset', function(req, res) {
   }
   var promiseSuccess = function(mathObjects) {
     var locals = {'mathObjects': mathObjects,
-                  'serverAddress': util.format('http://%s:%s/', SERVER, PORT)};
+                  'serverAddress': SERVER!='127.0.0.1' ? util.format('http://%s:%s/', SERVER, PORT) : 'http://'+req.headers.host+'/' };
     var htmlResult = Jade.renderFile('./views/slack-response.jade', locals);
     res.json({'text' : htmlResult});
     res.end();
@@ -49,7 +49,7 @@ router.post('/slashtypeset', function(req, res) {
   }
   var promiseSuccess = function(mathObjects) {
     var locals = {'mathObjects': mathObjects,
-                  'serverAddress': util.format('http://%s:%s/', SERVER, PORT)};
+                  'serverAddress': SERVER!='127.0.0.1' ? util.format('http://%s:%s/', SERVER, PORT) : 'http://'+req.headers.host+'/' };
     var htmlResult = Jade.renderFile('./views/slack-slash-response.jade', locals);
     res.send(htmlResult);
     res.end();

--- a/typeset.js
+++ b/typeset.js
@@ -32,6 +32,7 @@ var renderMath = function(mathObject, parseOptions) {
     ex: 12,
     width: 600,
     linebreaks: true,
+    timeout: 30 * 1000,
   };
   var typesetOptions = _.extend(defaultOptions, parseOptions);
   var deferred = Q.defer();

--- a/typeset.js
+++ b/typeset.js
@@ -25,7 +25,7 @@ var extractRawMath = function(text, prefix) {
 var renderMath = function(mathObject, parseOptions) {
   var defaultOptions = {
     math: mathObject.input,
-    format: 'AsciiMath',
+    format: 'TeX',
     png: true,
     dpi: 600,
     font: 'TeX',

--- a/typeset.js
+++ b/typeset.js
@@ -2,6 +2,7 @@ var MathJax = require('MathJax-node/lib/mj-single.js');
 var _ = require('underscore');
 var Q = require('q');
 var fs = require('fs');
+var crypto = require('crypto');
 
 MathJax.start();
 
@@ -41,7 +42,9 @@ var renderMath = function(mathObject, parseOptions) {
       deferred.reject(mathObject);
       return;
     }
-    var filename = encodeURIComponent(mathObject.input).replace(/\%/g, 'pc') + '.png';
+    var hash = crypto.createHash('sha256');
+    hash.update(mathObject.input);
+    var filename = hash.digest('hex') + '.png';
     var filepath = 'static/' + filename;
     if (!fs.existsSync(filepath)) {
       console.log('writing new PNG: %s', filename);

--- a/typeset.js
+++ b/typeset.js
@@ -8,7 +8,7 @@ MathJax.start();
 
 // Application logic for typesetting.
 var extractRawMath = function(text, prefix) {
-  var mathRegex = new RegExp("^\s*" + prefix + "\s*(.*)$","g");
+  var mathRegex = new RegExp("^\s*" + prefix + "\s*((\n|.)*)","g");
   var results = [];
   var match;
   while (match = mathRegex.exec(text)) {


### PR DESCRIPTION
I will propose some enhancement. Please review it.
### Dealing with HTML special chars

Math equations passed to the server is HTML encoded, so we should unescape such characters.

Please try this for example.

```
math! \begin{bmatrix} a & b \\ c & d \end{bmatrix}
```
### Host name autodetection

If one does not set the `SERVER` variable explicitly, use host name in request header instead to auto detect the image URL host name passed to Slack.
### .gitignore

Add `npm-debug.log` and `batik`, which should be ignored, to `.gitignore` entry.
